### PR TITLE
23: Save degree plan (Frontend)

### DIFF
--- a/client/src/app/s-degree-plan-editor/s-degree-plan-editor.component.html
+++ b/client/src/app/s-degree-plan-editor/s-degree-plan-editor.component.html
@@ -318,5 +318,8 @@
         </div>
       </div>
     </div>
+    <button mat-button-raised color="primary" (click)="onClickSubmitPlan()">
+      Submit
+    </button>
   </mat-card>
 </div>

--- a/client/src/app/s-degree-plan-editor/s-degree-plan-editor.component.ts
+++ b/client/src/app/s-degree-plan-editor/s-degree-plan-editor.component.ts
@@ -1,8 +1,11 @@
 import { Component, OnInit } from "@angular/core";
+import { Router } from "@angular/router";
+
 import { PlanService } from "../plan.service";
 import { UserService } from "../user.service";
-import { CourseData } from "../course.service";
 import { ErrorHandlerService } from "../error-handler.service";
+
+import { CourseData } from "../course.service";
 
 @Component({
   selector: "app-s-degree-plan-editor",
@@ -41,34 +44,27 @@ export class SDegreePlanEditorComponent implements OnInit {
     course?: CourseData;
   };
 
-  /**
-   * The following changes to types were made to make it easier to display them on the frontend.
-   * They will be reversed when using them for backend calls.
-   *
-   * (semester) status: Type Changed from Number to String
-   * (semester) units: Added field to semesters (Type Number)
-   * (semester) difficulty: Type Changed from String to Number
-   * (semester) isAddingSemester: Boolean, flag to check if user wants to add a semester
-   */
-
   constructor(
     private planService: PlanService,
     private userService: UserService,
-    private errorService: ErrorHandlerService
+    private errorService: ErrorHandlerService,
+    private router: Router
   ) {
+    this.plan = {};
+    this.courseList = [];
+    this.program = {};
+    this.draggedCourse = {
+      from: "",
+    };
+    this.addYearWidget = {
+      active: false,
+      yearField: 0,
+    };
+  }
+
+  ngOnInit() {
     this.planService.formatPlan().subscribe((result) => {
       this.plan = result;
-      this.plan.user = "";
-      this.plan.program = "";
-      this.plan.years.forEach((year) => {
-        year.newSemesterWidget = {
-          active: false,
-          termSelect: "",
-        };
-      });
-      this.userService.getUserData().subscribe((userResult) => {
-        this.plan.user = userResult.firstName;
-      });
     });
     this.planService.getProgramCourses().subscribe({
       next: (res) => {
@@ -79,233 +75,7 @@ export class SDegreePlanEditorComponent implements OnInit {
         this.errorService.handleError(errRes);
       },
     });
-
-    this.addYearWidget = {
-      active: false,
-      yearField: 0,
-    };
-
-    // this.setDummyData();
   }
-
-  /** Dummy data for plan used to demo markup */
-  setDummyData() {
-    this.plan = {
-      user: "",
-      program: "",
-      isAddingYear: false,
-      years: [
-        {
-          beginning: 2017,
-          ending: 2018,
-          newSemesterWidget: {
-            active: false,
-            termSelect: "",
-          },
-          semesters: [
-            {
-              term: "Fall",
-              year: 2017,
-              difficulty: 3.0,
-              units: 1.0,
-              courses: [
-                {
-                  school: "SJSU",
-                  department: "CMPE",
-                  code: "120",
-                  title: "Computer Architecture",
-                  credit: "3.0",
-                  description: "lorem ipsum",
-                  prerequisites: [],
-                  corequisites: [],
-                  area: "",
-                  type: [],
-                  difficulty: 1.0,
-                  impaction: 3.0,
-                  termsOffered: "Fall, Spring",
-                },
-                {
-                  school: "SJSU",
-                  department: "CMPE",
-                  code: "120",
-                  title: "Computer Architecture",
-                  credit: "3.0",
-                  description: "lorem ipsum",
-                  prerequisites: [],
-                  corequisites: [],
-                  area: "",
-                  type: [],
-                  difficulty: 2.0,
-                  impaction: 3.0,
-                  termsOffered: "Fall, Spring",
-                },
-              ],
-              status: "completed",
-            },
-            {
-              term: "Spring",
-              year: 2018,
-              difficulty: 1.4,
-              units: 1.0,
-              courses: [
-                {
-                  school: "SJSU",
-                  department: "CMPE",
-                  code: "120",
-                  title: "Computer Architecture",
-                  credit: "3.0",
-                  description: "lorem ipsum",
-                  prerequisites: [],
-                  corequisites: [],
-                  area: "",
-                  type: [],
-                  difficulty: 3.0,
-                  impaction: 2.0,
-                  termsOffered: "Fall, Spring",
-                },
-                {
-                  school: "SJSU",
-                  department: "CMPE",
-                  code: "120",
-                  title: "Computer Architecture",
-                  credit: "3.0",
-                  description: "lorem ipsum",
-                  prerequisites: [],
-                  corequisites: [],
-                  area: "",
-                  type: [],
-                  difficulty: 3.0,
-                  impaction: 1.0,
-                  termsOffered: "Fall, Spring",
-                },
-              ],
-              status: "completed",
-            },
-          ],
-        },
-        {
-          beginning: 2018,
-          ending: 2019,
-          newSemesterWidget: {
-            active: false,
-            termSelect: "",
-          },
-          semesters: [
-            {
-              term: "Fall",
-              year: 2018,
-              difficulty: 2.4,
-              units: 1.0,
-              courses: [
-                {
-                  school: "SJSU",
-                  department: "CMPE",
-                  code: "120",
-                  title: "Computer Architecture",
-                  credit: "3.0",
-                  description: "lorem ipsum",
-                  prerequisites: [],
-                  corequisites: [],
-                  area: "",
-                  type: [],
-                  difficulty: 1.0,
-                  impaction: 3.0,
-                  termsOffered: "Fall, Spring",
-                },
-                {
-                  school: "SJSU",
-                  department: "CMPE",
-                  code: "120",
-                  title: "Computer Architecture",
-                  credit: "3.0",
-                  description: "lorem ipsum",
-                  prerequisites: [],
-                  corequisites: [],
-                  area: "",
-                  type: [],
-                  difficulty: 2.0,
-                  impaction: 3.0,
-                  termsOffered: "Fall, Spring",
-                },
-              ],
-              status: "completed",
-            },
-            {
-              term: "Spring",
-              year: 2019,
-              difficulty: 3.2,
-              units: 1.0,
-              courses: [
-                {
-                  school: "SJSU",
-                  department: "CMPE",
-                  code: "120",
-                  title: "Computer Architecture",
-                  credit: "3.0",
-                  description: "lorem ipsum",
-                  prerequisites: [],
-                  corequisites: [],
-                  area: "",
-                  type: [],
-                  difficulty: 3.0,
-                  impaction: 2.0,
-                  termsOffered: "Fall, Spring",
-                },
-                {
-                  school: "SJSU",
-                  department: "CMPE",
-                  code: "120",
-                  title: "Computer Architecture",
-                  credit: "3.0",
-                  description: "lorem ipsum",
-                  prerequisites: [],
-                  corequisites: [],
-                  area: "",
-                  type: [],
-                  difficulty: 3.0,
-                  impaction: 1.0,
-                  termsOffered: "Fall, Spring",
-                },
-              ],
-              status: "completed",
-            },
-          ],
-        },
-      ],
-    };
-
-    /* Dummy data for course list to demo markup */
-    this.courseList = [
-      {
-        department: "CMPE",
-        courses: [
-          {
-            department: "CMPE",
-            code: "120",
-          },
-          {
-            department: "CMPE",
-            code: "131",
-          },
-        ],
-      },
-      {
-        department: "CS",
-        courses: [
-          {
-            department: "CS",
-            code: "146",
-          },
-          {
-            department: "CS",
-            code: "149",
-          },
-        ],
-      },
-    ];
-  }
-
-  ngOnInit() {}
 
   /**
    * Handles click event of "Add New Year" button
@@ -317,6 +87,7 @@ export class SDegreePlanEditorComponent implements OnInit {
         this.addYearWidget.yearField,
         this.plan.years
       );
+      this.addYearWidget.active = false;
     }
   }
 
@@ -334,6 +105,7 @@ export class SDegreePlanEditorComponent implements OnInit {
         yearIndex,
         this.plan.years
       );
+      this.plan.years[yearIndex].newSemesterWidget.active = false;
     }
   }
 
@@ -441,5 +213,19 @@ export class SDegreePlanEditorComponent implements OnInit {
     if (from === "semester-card") {
       this.planService.removeCourse(indexes, this.plan.years);
     }
+  }
+
+  /**
+   * Handles clicking on the "Submit" button
+   */
+  onClickSubmitPlan(): void {
+    this.planService.submitPlan(this.plan).subscribe({
+      complete: () => {
+        this.router.navigate(["dashboard"]);
+      },
+      error: (errRes) => {
+        this.errorService.handleError(errRes);
+      },
+    });
   }
 }

--- a/client/src/app/s-degree-plan/s-degree-plan.component.html
+++ b/client/src/app/s-degree-plan/s-degree-plan.component.html
@@ -23,8 +23,11 @@
         <div class="semester-cards-container">
           <!-- Semester Cards -->
           <div *ngFor="let semester of year.semesters" class="semester-card">
-            <div class="semester-card-term-and-status">
-              <span>{{ semester.term }} {{ semester.year }}</span>
+            <div
+              *ngIf="semester.term && semester.year"
+              class="semester-card-term-and-status"
+            >
+              <span>{{ semester.term | uppercase }} {{ semester.year }}</span>
               <span *ngIf="semester.status === -1">Planned</span>
               <span *ngIf="semester.status === 0">In-Progress</span>
               <span *ngIf="semester.status === 1">Completed</span>

--- a/client/src/app/s-degree-plan/s-degree-plan.component.ts
+++ b/client/src/app/s-degree-plan/s-degree-plan.component.ts
@@ -12,11 +12,7 @@ export class SDegreePlanComponent implements OnInit {
   yearArray: Observable<Array<Year>>;
   openPanel = false;
 
-  constructor(
-    private router: Router,
-    private errorHandler: ErrorHandler,
-    private planService: PlanService
-  ) {
+  constructor(private router: Router, private planService: PlanService) {
     this.openPanel = true;
   }
 


### PR DESCRIPTION
## Description
Frontend now calls the backend to actually edit plans in our database

## Major changes
1. In the plan service, I created convertSemestersForSubmission() and submitPlan() to reverse the data transformations made by the component and call the backend respectively. Also add onClickSubmitPlan() to handle clicking on the 'submit' button

2. Made some additions to the formatPlan() function in the plan service to include the fields for the add semesters widget. This is so that the edit plan component does not have to do it.

3. In the edit plan component, I moved backend fetch calls to the component ngOninit(). Constructor now only sets default values.

4. Removed the setDummyData() function in the edit plan component.