### PR TITLE
038: refresh student portal components on new user

### DIFF
--- a/client/src/app/plan.service.ts
+++ b/client/src/app/plan.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@angular/core";
-import { UserService, UserProfile } from "./user.service";
+import { UserService } from "./user.service";
 import { HttpClient } from "@angular/common/http";
 import { CourseData } from "./course.service";
 import { map } from "rxjs/operators";
@@ -31,11 +31,7 @@ export class PlanService {
     spring: 4,
   };
 
-  user: Observable<UserProfile>;
-
-  constructor(private userService: UserService, private http: HttpClient) {
-    this.user = this.userService.getUserData();
-  }
+  constructor(private userService: UserService, private http: HttpClient) {}
 
   /**
    * Formats the user's plan from their profile
@@ -111,7 +107,8 @@ export class PlanService {
       return [];
     };
 
-    return this.user.pipe(map(mapCallback));
+    // must call getUserData() to refresh the use plan when new user logs in
+    return this.userService.getUserData().pipe(map(mapCallback));
   }
 
   /**

--- a/client/src/app/s-dashboard/s-dashboard.component.html
+++ b/client/src/app/s-dashboard/s-dashboard.component.html
@@ -3,4 +3,4 @@
 <div class="mb16"></div>
 <app-s-courses-taken [hasNewProfile]="profileEvent"></app-s-courses-taken>
 <div class="mb16"></div>
-<app-s-degree-plan></app-s-degree-plan>
+<app-s-degree-plan [hasNewProfile]="profileEvent"></app-s-degree-plan>

--- a/client/src/app/s-degree-plan/s-degree-plan.component.html
+++ b/client/src/app/s-degree-plan/s-degree-plan.component.html
@@ -1,5 +1,5 @@
 <div class="flex-row justify-content-center align-items-center w100">
-  <mat-expansion-panel class="expansion-panel" [expanded]="true">
+  <mat-expansion-panel class="expansion-panel" [expanded]="openPanel">
     <mat-expansion-panel-header>
       <mat-panel-title>
         <!-- Expansion Panel Title -->

--- a/client/src/app/s-degree-plan/s-degree-plan.component.html
+++ b/client/src/app/s-degree-plan/s-degree-plan.component.html
@@ -147,7 +147,7 @@
       </div>
       <div class="semester-card-course-chip-and-difficulty">
         <div class="btn edit-plan-btn mt8" (click)="onClickEditPlan()">
-          Edit Plan
+          Design Your Degree Plan
         </div>
       </div>
     </div>

--- a/client/src/app/s-degree-plan/s-degree-plan.component.ts
+++ b/client/src/app/s-degree-plan/s-degree-plan.component.ts
@@ -17,7 +17,7 @@ export class SDegreePlanComponent implements OnInit {
     private errorHandler: ErrorHandler,
     private planService: PlanService
   ) {
-    this.yearArray = this.planService.formatPlan();
+    this.openPanel = true;
   }
 
   @Input() set hasNewProfile(event: Event) {
@@ -28,11 +28,10 @@ export class SDegreePlanComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.openPanel = true;
+    this.yearArray = this.planService.formatPlan();
   }
 
   onClickEditPlan() {
-    // TODO: ADD ROUTE AFTER ADDING EDIT PLAN
     this.router.navigate(["plan-editor"]);
   }
 }

--- a/client/src/app/s-degree-plan/s-degree-plan.component.ts
+++ b/client/src/app/s-degree-plan/s-degree-plan.component.ts
@@ -1,11 +1,7 @@
 import { Component, OnInit, ErrorHandler, Input } from "@angular/core";
 import { Router } from "@angular/router";
-
-import { UserService, UserProfile } from "../user.service";
-import { PlanService, Year } from "../plan.service";
-
 import { Observable } from "rxjs";
-import { share } from "rxjs/operators";
+import { PlanService, Year } from "../plan.service";
 
 @Component({
   selector: "app-s-degree-plan",
@@ -22,8 +18,6 @@ export class SDegreePlanComponent implements OnInit {
     private planService: PlanService
   ) {
     this.yearArray = this.planService.formatPlan();
-    this.openPanel = true;
-    this.yearArray.subscribe((result) => console.log(result));
   }
 
   @Input() set hasNewProfile(event: Event) {
@@ -33,7 +27,9 @@ export class SDegreePlanComponent implements OnInit {
     }
   }
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.openPanel = true;
+  }
 
   onClickEditPlan() {
     // TODO: ADD ROUTE AFTER ADDING EDIT PLAN

--- a/client/src/app/s-degree-plan/s-degree-plan.component.ts
+++ b/client/src/app/s-degree-plan/s-degree-plan.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ErrorHandler } from "@angular/core";
+import { Component, OnInit, ErrorHandler, Input } from "@angular/core";
 import { Router } from "@angular/router";
 
 import { UserService, UserProfile } from "../user.service";
@@ -14,6 +14,7 @@ import { share } from "rxjs/operators";
 })
 export class SDegreePlanComponent implements OnInit {
   yearArray: Observable<Array<Year>>;
+  openPanel = false;
 
   constructor(
     private router: Router,
@@ -21,7 +22,15 @@ export class SDegreePlanComponent implements OnInit {
     private planService: PlanService
   ) {
     this.yearArray = this.planService.formatPlan();
+    this.openPanel = true;
     this.yearArray.subscribe((result) => console.log(result));
+  }
+
+  @Input() set hasNewProfile(event: Event) {
+    if (event) {
+      this.yearArray = this.planService.formatPlan();
+      this.openPanel = true;
+    }
   }
 
   ngOnInit() {}

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -360,11 +360,11 @@ button:disabled {
 }
 
 .btn.edit-plan-btn {
-  background-color: #2ecc71;
+  background-color: #1abc9c;
   color: #ffffff;
 }
 
 .btn.edit-plan-btn:hover {
-  background-color: #27ae60;
+  background-color: #1abc9c;
   color: #ffffff;
 }


### PR DESCRIPTION
Refreshes the user degree plan when switch user accounts or when a transcript is uploaded. 
- Switch accounts
       = refreshes through the plan service in formatPlan() by called getUserData() from the user service
- Transcript upload
      = refreshes through Angular change detection by emitting an event from d-degree-profile (when a transcript is uploaded) through the parent component (dashboard) and into the sibling components (s-courses-taken & s-degree-plan)